### PR TITLE
增加线程池开关

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,10 +336,11 @@ public void testCustomFunc() {
 
 在组装好logDTO后，默认使用线程池对消息进行分发，发送至本地监听函数或者消息队列发送者。
 
-可以使用如下配置修改线程池大小
+可以使用如下配置开启或关闭线程池、修改线程池大小
 
 ```
-log-record.pool-size=4（默认为4）
+log-record.thread-pool.enabled=true（默认为true）
+log-record.thread-pool.pool-size=4（默认为4）
 ```
 
 

--- a/src/main/java/cn/monitor4all/logRecord/configuration/LogRecordProperties.java
+++ b/src/main/java/cn/monitor4all/logRecord/configuration/LogRecordProperties.java
@@ -1,5 +1,6 @@
 package cn.monitor4all.logRecord.configuration;
 
+import cn.monitor4all.logRecord.constants.LogConstants;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -14,9 +15,17 @@ public class LogRecordProperties {
 
     private StreamProperties stream;
 
+    private ThreadPoolProperties ThreadPool = new ThreadPoolProperties();
+
     private String dataPipeline;
 
-    private int poolSize = 4;
+    @Data
+    public static class ThreadPoolProperties {
+
+        private int poolSize = 4;
+
+        private boolean enabled = true;
+    }
 
     @Data
     public static class RabbitMqProperties {

--- a/src/main/java/cn/monitor4all/logRecord/thread/LogRecordThreadPool.java
+++ b/src/main/java/cn/monitor4all/logRecord/thread/LogRecordThreadPool.java
@@ -1,7 +1,9 @@
 package cn.monitor4all.logRecord.thread;
 
 import cn.monitor4all.logRecord.configuration.LogRecordProperties;
+import cn.monitor4all.logRecord.constants.LogConstants;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
@@ -11,15 +13,21 @@ import java.util.concurrent.*;
 @Slf4j
 @Component
 @EnableConfigurationProperties(value = LogRecordProperties.class)
+@ConditionalOnProperty(
+        prefix = "log-record.thread-pool",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true
+)
 public class LogRecordThreadPool {
 
     private static final ThreadFactory THREAD_FACTORY = new CustomizableThreadFactory("log-record-");
 
     private final ExecutorService LOG_RECORD_POOL_EXECUTOR;
 
-    public LogRecordThreadPool(LogRecordProperties logRecordProperties){
-        log.info("LogRecordThreadPool init poolSize [{}]", logRecordProperties.getPoolSize());
-        int poolSize = logRecordProperties.getPoolSize();
+    public LogRecordThreadPool(LogRecordProperties logRecordProperties) {
+        log.info("LogRecordThreadPool init poolSize [{}]", logRecordProperties.getThreadPool().getPoolSize());
+        int poolSize = logRecordProperties.getThreadPool().getPoolSize();
         this.LOG_RECORD_POOL_EXECUTOR = new ThreadPoolExecutor(poolSize, poolSize, 0L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(1024), THREAD_FACTORY, new ThreadPoolExecutor.CallerRunsPolicy());
     }
 


### PR DESCRIPTION
您好，您的项目很棒，很实用。

但是我在使用时发现， 存在request里的信息无法在处理log时获取到。我看是因为在处理日志时使用了多线程但是没有将主线程的request共享给子线程导致的。

我尝试简单使用RequestContextHolder设置共享，但是我发现您并没有引入spring-web包。我猜测可能是想专注于日志记录。

我认为如果想专注于日志处理，那么也应该将批量处理的具体实现交给用户自己，框架只负责提供日志信息，由用户决定是否添加此类功能并做对应处理。
现在这样一刀切而且没有关闭的地方我认为不太合理。

所以去掉了日志的多线程处理，并且在自定义处理接口上增加了批量处理方法留给用户自己按需实现。